### PR TITLE
adding extra validation for hidden SSID strings with backslashes

### DIFF
--- a/src/api/notificationListener.js
+++ b/src/api/notificationListener.js
@@ -21,7 +21,11 @@ import { listeners } from '../store'
 
 export default data => {
   if (typeof data === 'string') {
-    data = JSON.parse(data.normalize().replace(/\\x([0-9A-Fa-f]{2})/g, ''))
+    let regex1 = /\\\\x([0-9A-Fa-f]{2})/g //evaluating \\x00 pattern on hidden SSID
+    let regex2 = /\\x([0-9A-Fa-f]{2})/g //evaluating \x00 pattern on hidden SSID
+    data = data.normalize().replace(regex1, '')
+    data = data.normalize().replace(regex2, '')
+    data = JSON.parse(data)
   }
   // determine if we're dealing with a notification
   if (!data.id && data.method) {

--- a/src/api/requestQueueResolver.js
+++ b/src/api/requestQueueResolver.js
@@ -21,7 +21,11 @@ import { requestsQueue } from '../store'
 
 export default data => {
   if (typeof data === 'string') {
-    data = JSON.parse(data.normalize().replace(/\\x([0-9A-Fa-f]{2})/g, ''))
+    let regex1 = /\\\\x([0-9A-Fa-f]{2})/g //evaluating \\x00 pattern on hidden SSID
+    let regex2 = /\\x([0-9A-Fa-f]{2})/g //evaluating \x00 pattern on hidden SSID
+    data = data.normalize().replace(regex1, '')
+    data = data.normalize().replace(regex2, '')
+    data = JSON.parse(data)
   }
   if (data.id) {
     const request = requestsQueue[data.id]


### PR DESCRIPTION
Solution currently used to handle these new SSID entries with double backslashes:
Running the regex cases incrementally, so that if regex1 is a hit and gets applied, regex2 won't match and become void - otherwise, regex2 will do its job.

If accepted and merged, requesting a new tag from master, if possible.

Fixes #24